### PR TITLE
lots of updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ This is a Chrome Extension that will filter Pokemon Showdown so only the relevan
 ## Installation (Chromium, e.g. Edge, Chrome, Brave)
 
 1. Download this repository as a zip
-2. extract it
-3. open your **Chromium** based browser of choice
+2. Extract it
+3. Open your **Chromium** based browser of choice
 4. Type in your search bar: `chrome://extensions`
 5. Turn on developer mode
    * [Chrome](https://support.google.com/chrome/thread/155712634?hl=en&msgid=157192351)
@@ -19,13 +19,14 @@ This is a Chrome Extension that will filter Pokemon Showdown so only the relevan
 ### To install this current version from Github, you'd need to have the [developer version of Firefox](https://www.mozilla.org/en-US/firefox/developer) installed.
 
 1. Download this repository and branch as a .zip file. **(unlike the Chromium version, DO NOT EXTRACT IT)**
-2. Install the **developer version** of Firefox
-3. open the **developer version** of Firefox
-4. type in your adress bar `about:config` and click Enter
-5. type in the search bar `xpinstall.signatures.required` And toggle it from `True` to `False`
-6. Go to `about:addons` on your search bar
-7. click on the gear wheel and select `install Addon from File`
-8. Select the downloaded zip file and select `Open`
+2. In the root of the zip file is one folder; move all of its contents to the root of the zip file.
+3. Install the **developer version** of Firefox
+4. open the **developer version** of Firefox
+5. type in your adress bar `about:config` and click Enter
+6. type in the search bar `xpinstall.signatures.required` And toggle it from `True` to `False`
+7. Go to `about:addons` on your search bar
+8. click on the gear wheel and select `install Addon from File`
+9. Select the downloaded zip file and select `Open`
 
 
 ## Developers

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 3,
     "name": "35 Pokes Showdown Filter",
     "description": "This extension allows 35 Pokes users to filter the showdown teambuilder in order to only display the 35 current pokemon.",
-    "version": "1.2",
+    "version": "1.3",
     "icons": {
         "16": "images/35_logo.PNG",
         "32": "images/35_logo.PNG",
@@ -22,6 +22,7 @@
         "storage"
     ],
     "host_permissions": [
+        "https://play.pokemonshowdown.com/*",
         "https://samuel-peter-chowdhury.github.io/*"
     ],
     "browser_specific_settings": {

--- a/manifest.json
+++ b/manifest.json
@@ -22,7 +22,6 @@
         "storage"
     ],
     "host_permissions": [
-        "https://play.pokemonshowdown.com/*",
         "https://samuel-peter-chowdhury.github.io/*"
     ],
     "browser_specific_settings": {

--- a/popup/popup.css
+++ b/popup/popup.css
@@ -161,10 +161,14 @@ html {
                 display: none;
                 flex-direction: column;
                 color: #FFD700;
-                font-size: 16px;
 
                 .message-text:not(:first-child) {
                     margin-top: 16px;
+                }
+
+                .message-text {
+                    font-size: 12px;
+                    font-weight: bold;
                 }
             }
         }

--- a/popup/popup.css
+++ b/popup/popup.css
@@ -158,7 +158,7 @@ html {
             }
 
             .message-container {
-                display: flex;
+                display: none;
                 flex-direction: column;
                 color: #FFD700;
                 font-size: 16px;

--- a/popup/popup.css
+++ b/popup/popup.css
@@ -1,10 +1,12 @@
 html {
     padding: 0;
     margin: 0;
+    height: fit-content;
 
     body {
         padding: 0;
         margin: 0;
+        height: fit-content;
     
         .popup-container {
             display: flex;
@@ -144,6 +146,25 @@ html {
 
                 i {
                     margin-left: 5px;
+                }
+            }
+
+            .footer-parent {
+                display: flex;
+                flex-direction: row;
+                width: 100%;
+                justify-content: space-between;
+                align-items: center;
+            }
+
+            .message-container {
+                display: flex;
+                flex-direction: column;
+                color: #FFD700;
+                font-size: 16px;
+
+                .message-text:not(:first-child) {
+                    margin-top: 16px;
                 }
             }
         }

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -22,7 +22,6 @@
                     <input id="toggle-input" type="checkbox">
                     <span class="slider round"></span>
                 </label>
-                <!-- <span id="copy-text" class="copy-text">Copied!</span> -->
             </div>
             <div id="message-container" class="message-container"></div>
         </div>

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -17,10 +17,14 @@
             <div class="button-container">
                 <button id="code-button" class="copy-button">Challenge Code<i class="fa fa-copy"></i></button>
             </div>
-            <label class="popup-switch">
-                <input id="toggle-input" type="checkbox">
-                <span class="slider round"></span>
-            </label>
+            <div class="footer-parent">
+                <label class="popup-switch">
+                    <input id="toggle-input" type="checkbox">
+                    <span class="slider round"></span>
+                </label>
+                <!-- <span id="copy-text" class="copy-text">Copied!</span> -->
+            </div>
+            <div id="message-container" class="message-container"></div>
         </div>
     </body>
 </html>

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -1,15 +1,16 @@
 // Polyfill for browser compatibility
-if (typeof browser === 'undefined') {
-    var browser = chrome;
-}
+if (typeof browser === "undefined") globalThis.browser = chrome;
 
-const months = new Map([['jan', 1], ['feb', 2], ['mar', 3], ['apr', 4], ['may', 5], ['jun', 6], ['jul', 7], ['aug', 8], ['sep', 9], ['oct', 10], ['nov', 11], ['dec', 12]])
+const months = new Map([[1, 'jan'], [2, 'feb'], [3, 'mar'], [4, 'apr'], [5, 'may'], [6, 'jun'], [7, 'jul'], [8, 'aug'], [9, 'sep'], [10, 'oct'], [11, 'nov'], [12, 'dec']]);
 const years = [2023, 2024, 2025, 2026, 2027, 2028, 2029, 2030];
 const currentDate = new Date();
 
 document.addEventListener("DOMContentLoaded", function() {
+    const messageContainer = document.getElementById('message-container');
+
+    // Toggle
     const toggleElement = document.getElementById('toggle-input');
-    browser.storage.local.get(['35pokes-toggleState'], function(items) {
+    browser.storage.local.get(['35pokes-toggleState']).then(items => {
         if (items['35pokes-toggleState']) {
             toggleElement.value = items['35pokes-toggleState'];
             toggleElement.checked = items['35pokes-toggleState'];
@@ -19,28 +20,33 @@ document.addEventListener("DOMContentLoaded", function() {
         }
     });
     toggleElement.addEventListener('change', function() {
-        browser.storage.local.set({ '35pokes-toggleState': this.checked }, function() {});
+        browser.storage.local.set({ '35pokes-toggleState': this.checked });
+        messageTabs({ toggleSet: this.checked });
+        fetchAllowedPokemonDataAndSetStorage().then(onPopupActivity); // remove this for 1.4
     });
 
+    // Month Input
     const monthElement = document.getElementById('month-select');
     months.forEach((value, key) => {
         let opt = document.createElement('option');
-        opt.value = value;
-        opt.innerHTML = key;
+        opt.value = key;
+        opt.innerHTML = value;
         monthElement.appendChild(opt);
     });
-    browser.storage.local.get(['35pokes-month'], function(items) {
+    browser.storage.local.get(['35pokes-month']).then(items => {
         if (items['35pokes-month']) {
             monthElement.value = items['35pokes-month'];
         } else {
             monthElement.value = currentDate.getUTCMonth() + 1;
-            browser.storage.local.set({ '35pokes-month': currentDate.getUTCMonth() + 1 }, function() {});
+            browser.storage.local.set({ '35pokes-month': currentDate.getUTCMonth() + 1 });
         }
     });
     monthElement.addEventListener('change', function() {
-        browser.storage.local.set({ '35pokes-month': this.value }, function() {});
+        browser.storage.local.set({ '35pokes-month': Number(this.value) });
+        fetchAllowedPokemonDataAndSetStorage().then(onPopupActivity);
     });
 
+    // Year Input
     const yearElement = document.getElementById('year-select');
     years.forEach(y => {
         let opt = document.createElement('option');
@@ -48,40 +54,100 @@ document.addEventListener("DOMContentLoaded", function() {
         opt.innerHTML = y;
         yearElement.appendChild(opt);
     });
-    browser.storage.local.get(['35pokes-year'], function(items) {
+    browser.storage.local.get(['35pokes-year']).then(items => {
         if (items['35pokes-year']) {
             yearElement.value = items['35pokes-year'];
         } else {
             yearElement.value = currentDate.getUTCFullYear();
-            browser.storage.local.set({ '35pokes-year': currentDate.getUTCFullYear() }, function() {});
+            browser.storage.local.set({ '35pokes-year': currentDate.getUTCFullYear() });
         }
     });
     yearElement.addEventListener('change', function() {
-        browser.storage.local.set({ '35pokes-year': this.value }, function() {});
+        browser.storage.local.set({ '35pokes-year': Number(this.value) });
+        fetchAllowedPokemonDataAndSetStorage().then(onPopupActivity);
     });
 
+    // Text Input
     const textElement = document.getElementById('text-input');
-    browser.storage.local.get(['35pokes-text'], function(items) {
+    browser.storage.local.get(['35pokes-text']).then(items => {
         if (items['35pokes-text']) {
             textElement.value = items['35pokes-text'];
         } else {
             textElement.value = '';
-            browser.storage.local.set({ '35pokes-text': '' }, function() {});
+            browser.storage.local.set({ '35pokes-text': '' });
         }
     });
     textElement.addEventListener('change', function() {
-        browser.storage.local.set({ '35pokes-text': this.value }, function() {});
+        browser.storage.local.set({ '35pokes-text': this.value });
+        fetchAllowedPokemonDataAndSetStorage().then(onPopupActivity);
     });
 
     const buttonElement = document.getElementById('code-button');
     buttonElement.addEventListener('click', function() {
-        browser.storage.local.get(['35pokes-code'], function(items) {
-            if (items['35pokes-code']) {
-                navigator.clipboard.writeText(items['35pokes-code']);
-                alert('Challenge code copied to clipboard.');
-            } else {
-                alert('No challenge code was found, please reload the page.');
-            }
+        let challengeCodePrefix = '/challenge gen9nationaldexag @@@ Z-Move Clause, -Mega, Terastal Clause, Sleep Clause Mod, Forme Clause, -Hidden Power, -Last Respects, -Kings Rock, -Shadow Tag, -Acupressure, -Battle Bond, -Quick Claw, -Razor Fang, Evasion Clause, OHKO Clause, baton pass stat trap clause, -All Pokemon, +';
+        browser.storage.local.get('35pokes-list').then(items => {
+            if(items['35pokes-list']) navigator.clipboard.writeText(challengeCodePrefix + items['35pokes-list'].join(', +')).then(() => showMessage('Copied!'));
+            else showMessage("This meta doesn't exist yet!");
         });
     });
+
+    function onPopupActivity(result) {
+        let textPrefix = result.list ? "Meta set to:<br>" : "Meta not found:<br>";
+        let textSuffix = result.text ? " " + result.text : "";
+        showMessage(textPrefix + result.month + " " + result.year + textSuffix);
+        messageTabs(result);
+    }
+
+    // This replaces alert() because alert breaks clipboard functionality on every browser.
+    // also alert in popup is unreadable for firefox users.
+    function showMessage(msg) {
+        const text = document.createElement("span");
+        text.className = "message-text";
+        text.innerHTML = msg;
+        text.style.opacity = 1;
+        messageContainer.appendChild(text);
+        setTimeout(() => {
+            let fadeout = setInterval(() => {
+                text.style.opacity -= 0.1;
+                if(text.style.opacity == 0) {
+                    messageContainer.removeChild(text);
+                    clearInterval(fadeout);
+                }
+            }, 100);
+        }, 5 * 1000);
+    }
 });
+
+async function fetchAllowedPokemonDataAndSetStorage() {
+    // Default metagame in case the storage gets wiped.
+    let storageItems = await browser.storage.local.get({
+        '35pokes-month': 5,
+        '35pokes-year': 2024,
+        '35pokes-text': ''
+    });
+    let textPrefix = 'https://samuel-peter-chowdhury.github.io/35PokesShowdownFilter/dates/';
+    let textSuffix = storageItems['35pokes-text'] ? '_' + storageItems['35pokes-text'] : '';
+    let fileName = textPrefix + storageItems['35pokes-year'] + '_' + storageItems['35pokes-month'] + textSuffix + '.json';
+
+    let allowedMons = "";
+    let response = await fetch(fileName);
+    if(response.ok) allowedMons = await response.json();
+    browser.storage.local.set({ '35pokes-list': allowedMons });
+    return {
+        month: storageItems['35pokes-month'],
+        year: storageItems['35pokes-year'],
+        text: storageItems['35pokes-text'],
+        list: allowedMons
+    };
+}
+
+function messageTabs(data) {
+    browser.tabs.query({
+        url: "https://play.pokemonshowdown.com/*",
+        discarded: false
+    }).then(psTabs => {
+        psTabs.forEach(tab => {
+            browser.tabs.sendMessage(tab.id, data);
+        });
+    });
+}

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -1,7 +1,7 @@
 // Polyfill for browser compatibility
 if (typeof browser === "undefined") globalThis.browser = chrome;
 
-const months = new Map([[1, 'jan'], [2, 'feb'], [3, 'mar'], [4, 'apr'], [5, 'may'], [6, 'jun'], [7, 'jul'], [8, 'aug'], [9, 'sep'], [10, 'oct'], [11, 'nov'], [12, 'dec']]);
+const months = new Map([['jan', 1], ['feb', 2], ['mar', 3], ['apr', 4], ['may', 5], ['jun', 6], ['jul', 7], ['aug', 8], ['sep', 9], ['oct', 10], ['nov', 11], ['dec', 12]]);
 const years = [2023, 2024, 2025, 2026, 2027, 2028, 2029, 2030];
 const currentDate = new Date();
 
@@ -29,8 +29,8 @@ document.addEventListener("DOMContentLoaded", function() {
     const monthElement = document.getElementById('month-select');
     months.forEach((value, key) => {
         let opt = document.createElement('option');
-        opt.value = key;
-        opt.innerHTML = value;
+        opt.value = value;
+        opt.innerHTML = key;
         monthElement.appendChild(opt);
     });
     browser.storage.local.get(['35pokes-month']).then(items => {
@@ -84,7 +84,7 @@ document.addEventListener("DOMContentLoaded", function() {
 
     const buttonElement = document.getElementById('code-button');
     buttonElement.addEventListener('click', function() {
-        let challengeCodePrefix = '/challenge gen9nationaldexag @@@ Z-Move Clause, -Mega, Terastal Clause, Sleep Clause Mod, Forme Clause, -Hidden Power, -Last Respects, -Kings Rock, -Shadow Tag, -Acupressure, -Battle Bond, -Quick Claw, -Razor Fang, Evasion Clause, OHKO Clause, baton pass stat trap clause, -All Pokemon, +';
+        const challengeCodePrefix = '/challenge gen9nationaldexag @@@ Z-Move Clause, -Mega, Terastal Clause, Sleep Clause Mod, Forme Clause, -Hidden Power, -Last Respects, -Kings Rock, -Shadow Tag, -Acupressure, -Battle Bond, -Quick Claw, -Razor Fang, Evasion Clause, OHKO Clause, baton pass stat trap clause, -All Pokemon, +';
         browser.storage.local.get('35pokes-list').then(items => {
             if(items['35pokes-list']) navigator.clipboard.writeText(challengeCodePrefix + items['35pokes-list'].join(', +')).then(() => showMessage('Copied!'));
             else showMessage("This meta doesn't exist yet!");
@@ -105,12 +105,14 @@ document.addEventListener("DOMContentLoaded", function() {
         text.className = "message-text";
         text.innerHTML = msg;
         text.style.opacity = 1;
+        messageContainer.style.display = "flex";
         messageContainer.appendChild(text);
         setTimeout(() => {
             let fadeout = setInterval(() => {
                 text.style.opacity -= 0.1;
                 if(text.style.opacity == 0) {
                     messageContainer.removeChild(text);
+                    if(messageContainer.childElementCount === 0) messageContainer.style.display = "none";
                     clearInterval(fadeout);
                 }
             }, 100);

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -5,22 +5,30 @@ const months = new Map([[1, 'jan'], [2, 'feb'], [3, 'mar'], [4, 'apr'], [5, 'may
 const years = [2023, 2024, 2025, 2026, 2027, 2028, 2029, 2030];
 const currentDate = new Date();
 
+const KEY_TOGGLESTATE = "35pokes-toggleState";
+const KEY_MONTH = "35pokes-month";
+const KEY_YEAR = "35pokes-year";
+const KEY_TEXT = "35pokes-text";
+const KEY_LIST = "35pokes-list";
+// Keys to be deleted from storage for 1.4:
+// "35pokes-code"
+
 document.addEventListener("DOMContentLoaded", function() {
     const messageContainer = document.getElementById('message-container');
 
     // Toggle
     const toggleElement = document.getElementById('toggle-input');
-    browser.storage.local.get(['35pokes-toggleState']).then(items => {
-        if (items['35pokes-toggleState']) {
-            toggleElement.value = items['35pokes-toggleState'];
-            toggleElement.checked = items['35pokes-toggleState'];
+    browser.storage.local.get(KEY_TOGGLESTATE).then(items => {
+        if (items[KEY_TOGGLESTATE]) {
+            toggleElement.value = items[KEY_TOGGLESTATE];
+            toggleElement.checked = items[KEY_TOGGLESTATE];
         } else {
             toggleElement.value = false;
             toggleElement.checked = false;
         }
     });
     toggleElement.addEventListener('change', function() {
-        browser.storage.local.set({ '35pokes-toggleState': this.checked });
+        browser.storage.local.set({ [KEY_TOGGLESTATE]: this.checked });
         messageTabs({ toggleSet: this.checked });
         fetchAllowedPokemonDataAndSetStorage().then(onPopupActivity); // remove this for 1.4
     });
@@ -33,16 +41,16 @@ document.addEventListener("DOMContentLoaded", function() {
         opt.innerHTML = value;
         monthElement.appendChild(opt);
     });
-    browser.storage.local.get(['35pokes-month']).then(items => {
-        if (items['35pokes-month']) {
-            monthElement.value = items['35pokes-month'];
+    browser.storage.local.get(KEY_MONTH).then(items => {
+        if (items[KEY_MONTH]) {
+            monthElement.value = items[KEY_MONTH];
         } else {
             monthElement.value = currentDate.getUTCMonth() + 1;
-            browser.storage.local.set({ '35pokes-month': currentDate.getUTCMonth() + 1 });
+            browser.storage.local.set({ [KEY_MONTH]: currentDate.getUTCMonth() + 1 });
         }
     });
     monthElement.addEventListener('change', function() {
-        browser.storage.local.set({ '35pokes-month': Number(this.value) });
+        browser.storage.local.set({ [KEY_MONTH]: Number(this.value) });
         fetchAllowedPokemonDataAndSetStorage().then(onPopupActivity);
     });
 
@@ -54,45 +62,45 @@ document.addEventListener("DOMContentLoaded", function() {
         opt.innerHTML = y;
         yearElement.appendChild(opt);
     });
-    browser.storage.local.get(['35pokes-year']).then(items => {
-        if (items['35pokes-year']) {
-            yearElement.value = items['35pokes-year'];
+    browser.storage.local.get(KEY_YEAR).then(items => {
+        if (items[KEY_YEAR]) {
+            yearElement.value = items[KEY_YEAR];
         } else {
             yearElement.value = currentDate.getUTCFullYear();
-            browser.storage.local.set({ '35pokes-year': currentDate.getUTCFullYear() });
+            browser.storage.local.set({ [KEY_YEAR]: currentDate.getUTCFullYear() });
         }
     });
     yearElement.addEventListener('change', function() {
-        browser.storage.local.set({ '35pokes-year': Number(this.value) });
+        browser.storage.local.set({ [KEY_YEAR]: Number(this.value) });
         fetchAllowedPokemonDataAndSetStorage().then(onPopupActivity);
     });
 
     // Text Input
     const textElement = document.getElementById('text-input');
-    browser.storage.local.get(['35pokes-text']).then(items => {
-        if (items['35pokes-text']) {
-            textElement.value = items['35pokes-text'];
+    browser.storage.local.get(KEY_TEXT).then(items => {
+        if (items[KEY_TEXT]) {
+            textElement.value = items[KEY_TEXT];
         } else {
             textElement.value = '';
-            browser.storage.local.set({ '35pokes-text': '' });
+            browser.storage.local.set({ [KEY_TEXT]: '' });
         }
     });
     textElement.addEventListener('change', function() {
-        browser.storage.local.set({ '35pokes-text': this.value });
+        browser.storage.local.set({ [KEY_TEXT]: this.value });
         fetchAllowedPokemonDataAndSetStorage().then(onPopupActivity);
     });
 
     const buttonElement = document.getElementById('code-button');
     buttonElement.addEventListener('click', function() {
         const challengeCodePrefix = '/challenge gen9nationaldexag @@@ Z-Move Clause, -Mega, Terastal Clause, Sleep Clause Mod, Forme Clause, -Hidden Power, -Last Respects, -Kings Rock, -Shadow Tag, -Acupressure, -Battle Bond, -Quick Claw, -Razor Fang, Evasion Clause, OHKO Clause, baton pass stat trap clause, -All Pokemon, +';
-        browser.storage.local.get('35pokes-list').then(items => {
-            if(items['35pokes-list']) navigator.clipboard.writeText(challengeCodePrefix + items['35pokes-list'].join(', +')).then(() => showMessage('Copied!'));
+        browser.storage.local.get(KEY_LIST).then(items => {
+            if(items[KEY_LIST]) navigator.clipboard.writeText(challengeCodePrefix + items[KEY_LIST].join(', +')).then(() => showMessage('Copied!'));
             else showMessage("This meta doesn't exist yet!");
         });
     });
 
     function onPopupActivity(result) {
-        const textPrefix = result.list ? "Date set:<br>" : "Meta not found:<br>";
+        const textPrefix = result.list ? "Date set: " : "Meta not found: ";
         const textSuffix = result.text ? " " + result.text : "";
         showMessage(textPrefix + months.get(result.month) + " " + result.year + textSuffix);
         messageTabs(result);
@@ -123,22 +131,22 @@ document.addEventListener("DOMContentLoaded", function() {
 async function fetchAllowedPokemonDataAndSetStorage() {
     // Default metagame in case the storage gets wiped.
     const storageItems = await browser.storage.local.get({
-        '35pokes-month': 5,
-        '35pokes-year': 2024,
-        '35pokes-text': ''
+        [KEY_MONTH]: 5,
+        [KEY_YEAR]: 2024,
+        [KEY_TEXT]: ''
     });
     const textPrefix = 'https://samuel-peter-chowdhury.github.io/35PokesShowdownFilter/dates/';
-    const textSuffix = storageItems['35pokes-text'] ? '_' + storageItems['35pokes-text'] : '';
-    const fileName = textPrefix + storageItems['35pokes-year'] + '_' + storageItems['35pokes-month'] + textSuffix + '.json';
+    const textSuffix = storageItems[KEY_TEXT] ? '_' + storageItems[KEY_TEXT] : '';
+    const fileName = textPrefix + storageItems[KEY_YEAR] + '_' + storageItems[KEY_MONTH] + textSuffix + '.json';
 
     let allowedMons = "";
     const response = await fetch(fileName);
     if(response.ok) allowedMons = await response.json();
-    browser.storage.local.set({ '35pokes-list': allowedMons });
+    browser.storage.local.set({ [KEY_LIST]: allowedMons });
     return {
-        month: storageItems['35pokes-month'],
-        year: storageItems['35pokes-year'],
-        text: storageItems['35pokes-text'],
+        month: storageItems[KEY_MONTH],
+        year: storageItems[KEY_YEAR],
+        text: storageItems[KEY_LIST],
         list: allowedMons
     };
 }

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -1,7 +1,7 @@
 // Polyfill for browser compatibility
 if (typeof browser === "undefined") globalThis.browser = chrome;
 
-const months = new Map([['jan', 1], ['feb', 2], ['mar', 3], ['apr', 4], ['may', 5], ['jun', 6], ['jul', 7], ['aug', 8], ['sep', 9], ['oct', 10], ['nov', 11], ['dec', 12]]);
+const months = new Map([[1, 'jan'], [2, 'feb'], [3, 'mar'], [4, 'apr'], [5, 'may'], [6, 'jun'], [7, 'jul'], [8, 'aug'], [9, 'sep'], [10, 'oct'], [11, 'nov'], [12, 'dec']]);
 const years = [2023, 2024, 2025, 2026, 2027, 2028, 2029, 2030];
 const currentDate = new Date();
 
@@ -28,9 +28,9 @@ document.addEventListener("DOMContentLoaded", function() {
     // Month Input
     const monthElement = document.getElementById('month-select');
     months.forEach((value, key) => {
-        let opt = document.createElement('option');
-        opt.value = value;
-        opt.innerHTML = key;
+        const opt = document.createElement('option');
+        opt.value = key;
+        opt.innerHTML = value;
         monthElement.appendChild(opt);
     });
     browser.storage.local.get(['35pokes-month']).then(items => {
@@ -49,7 +49,7 @@ document.addEventListener("DOMContentLoaded", function() {
     // Year Input
     const yearElement = document.getElementById('year-select');
     years.forEach(y => {
-        let opt = document.createElement('option');
+        const opt = document.createElement('option');
         opt.value = y;
         opt.innerHTML = y;
         yearElement.appendChild(opt);
@@ -92,9 +92,9 @@ document.addEventListener("DOMContentLoaded", function() {
     });
 
     function onPopupActivity(result) {
-        let textPrefix = result.list ? "Meta set to:<br>" : "Meta not found:<br>";
-        let textSuffix = result.text ? " " + result.text : "";
-        showMessage(textPrefix + result.month + " " + result.year + textSuffix);
+        const textPrefix = result.list ? "Date set:<br>" : "Meta not found:<br>";
+        const textSuffix = result.text ? " " + result.text : "";
+        showMessage(textPrefix + months.get(result.month) + " " + result.year + textSuffix);
         messageTabs(result);
     }
 
@@ -122,17 +122,17 @@ document.addEventListener("DOMContentLoaded", function() {
 
 async function fetchAllowedPokemonDataAndSetStorage() {
     // Default metagame in case the storage gets wiped.
-    let storageItems = await browser.storage.local.get({
+    const storageItems = await browser.storage.local.get({
         '35pokes-month': 5,
         '35pokes-year': 2024,
         '35pokes-text': ''
     });
-    let textPrefix = 'https://samuel-peter-chowdhury.github.io/35PokesShowdownFilter/dates/';
-    let textSuffix = storageItems['35pokes-text'] ? '_' + storageItems['35pokes-text'] : '';
-    let fileName = textPrefix + storageItems['35pokes-year'] + '_' + storageItems['35pokes-month'] + textSuffix + '.json';
+    const textPrefix = 'https://samuel-peter-chowdhury.github.io/35PokesShowdownFilter/dates/';
+    const textSuffix = storageItems['35pokes-text'] ? '_' + storageItems['35pokes-text'] : '';
+    const fileName = textPrefix + storageItems['35pokes-year'] + '_' + storageItems['35pokes-month'] + textSuffix + '.json';
 
     let allowedMons = "";
-    let response = await fetch(fileName);
+    const response = await fetch(fileName);
     if(response.ok) allowedMons = await response.json();
     browser.storage.local.set({ '35pokes-list': allowedMons });
     return {

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -1,9 +1,9 @@
 // Polyfill for browser compatibility
 if (typeof browser === "undefined") globalThis.browser = chrome;
 
-let metaMonth, metaYear, metaText;
-let allowedMap = new Map();
-let removedElements = [];
+let metaText;
+const allowedMap = new Map();
+const removedElements = [];
 const observer = new MutationObserver(onMutation);
 
 // Receive settings as the user changes them.
@@ -21,8 +21,6 @@ browser.runtime.onMessage.addListener((message) => {
     // Selected meta changed
     allowedMap.clear();
     if(message.list) message.list.forEach(item => allowedMap.set(item.toLowerCase()));
-    metaMonth = message.month;
-    metaYear = message.year;
     metaText = message.text;
 });
 
@@ -30,13 +28,9 @@ browser.runtime.onMessage.addListener((message) => {
 browser.storage.local.get({
     '35pokes-toggleState': false,
     '35pokes-list': [],
-    '35pokes-month': 5,
-    '35pokes-year': 2024,
     '35pokes-text': ''
 }).then(data => {
     data['35pokes-list'].forEach(item => allowedMap.set(item.toLowerCase()));
-    metaMonth = data['35pokes-month'];
-    metaYear = data['35pokes-year'];
     metaText = data['35pokes-text'];
     if(data['35pokes-toggleState']) observer.observe(document, {
         childList: true,
@@ -50,12 +44,6 @@ function onMutation(mutations) {
     for (const { addedNodes } of mutations) {
         for (const node of addedNodes) {
             if(!node.tagName) continue;
-
-            const setchart = node.getElementsByClassName('setchart')[0];
-            if(setchart?.childElementCount === 1) {
-                displayMeta(setchart);
-                continue;
-            }
             const elements = node.getElementsByClassName('teambuilder-results')[0];
             if(elements) {
                 console.log('35Pokes Filtering Chart... (teambuilder-results)');
@@ -85,7 +73,7 @@ function filterChart(chart) {
 
     setTimeout(function() {
         chart.scrollTop = 0;
-        removedElements = [];
+        removedElements.length = 0;
 
         let chartType = filterHeaders(chart);
         filterEntries(chart, chartType);
@@ -131,15 +119,4 @@ function unsetHeight(parentElement) {
     if (childElement) {
         childElement.style = null;
     }
-}
-
-function displayMeta(chart) {
-    let insert = document.createElement("div");
-    insert.style.float = "right";
-    insert.style.textAlign = "right";
-    insert.style.marginTop = "1%";
-    insert.style.marginRight = "1%";
-    insert.style.color = "#ddd";
-    insert.innerHTML = "35Pokes Filter:<br>" + metaMonth + " " + metaYear + " " + metaText;
-    chart.appendChild(insert);
 }

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -13,14 +13,11 @@ const KEY_MONTH = "35pokes-month";
 
 // Receive settings as the user changes them.
 browser.storage.local.onChanged.addListener(items => {
-    console.log(items);
     if(items[KEY_LIST]) {
-        console.log(1);
         allowedMap.clear();
         if(items[KEY_LIST].newValue) items[KEY_LIST].newValue.forEach(item => allowedMap.set(item.toLowerCase()));
     }
     else if(items[KEY_TOGGLESTATE]) {
-        console.log(2);
         if(items[KEY_TOGGLESTATE].newValue) observer.observe(document, {
             childList: true,
             subtree: true,
@@ -28,7 +25,6 @@ browser.storage.local.onChanged.addListener(items => {
         else observer.disconnect();
     }
     else if(items[KEY_TEXT]) {
-        console.log(3);
         metaText = items[KEY_TEXT].newValue;
     }
 });
@@ -43,7 +39,6 @@ browser.storage.local.get({
     if(data[KEY_TEXT]) metaText = data[KEY_TEXT];
     if(data[KEY_LIST]) data[KEY_LIST].forEach(item => allowedMap.set(item.toLowerCase()));
     else if(data[KEY_MONTH]) {
-        console.log("35Pokes Filter handling update to version 1.3");
         // make the user open popup which populates KEY_LIST
         browser.storage.local.set({
             [KEY_MONTH]: '',
@@ -67,13 +62,11 @@ function onMutation(mutations) {
             if(!node.tagName) continue;
             const elements = node.getElementsByClassName('teambuilder-results')[0];
             if(elements) {
-                console.log('35Pokes Filtering Chart... (teambuilder-results)');
                 filterChart(elements);
                 return;
             }
             const results = node.getElementsByClassName('result')[0];
             if(results) {
-                console.log('35Pokes Filtering Chart... (result)');
                 filterChart(results.parentElement.parentElement);
                 return;
             }

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -117,7 +117,7 @@ function filterEntries(parentElement, chartType) {
         }
     });
     // Don't filter out hidden power for old gens.
-    else if(chartType === "Moves") if(!/RBY|GSC|ADV|BW|ORAS|SM/.test(metaText)) entries.forEach(entry => {
+    else if(chartType === "Moves") if(!/^(RBY|GSC|ADV|BW|ORAS|SM)$/.test(metaText)) entries.forEach(entry => {
         const moveName = entry.querySelector('a[data-entry^="move|"]')?.getAttribute('data-entry')?.split('|')[1];
         if(moveName && /Hidden Power/.test(moveName)) {
             entry.style.display = 'none';


### PR DESCRIPTION
updates:
- filter out Hidden Power in movepools.
- teambuilder and the challenge code button immediately reflect changes made in popup (used to require a reload of showdown).
- show metagame date in a corner if there's empty space (eye candy).
- updated firefox readme instructions.
- replaced some outdated code (massive xhr function, callbacks when promises are available).
fixes:
- replaced alert() in popup because it was broken af.
- fix movepool headers (`Moves`, `Usually useless moves`) getting removed in some cases.
- fix mobile view behavior getting applied to desktop users as well.

we should introduce a service worker for 1.4 and move a lot of code there. for now, i avoided doing this, because doing so would require a new branch for kiwi browser or dropping support for it until it updates (neither option is very user friendly)